### PR TITLE
Use a named volume for the DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ In a shell run:
 dup
 ```
 *NOTE: `dup` is an alias. To review the actual command see the `aliases` below*
+*NOTE: The db container expects to expose 5432 to your host machine. If you already have postgres running locally you will need to stop your server to avoid a conflict.*
 
 This will run docker-compose to stand up two containers: `api` and `db`
 *NOTE: These containers know how to talk to each other via docker networking.*

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Here are some useful docker aliases for this project:
 ```bash
 # Usage: ddown
 alias ddown="docker-compose -p launchpad down"
-alias ddownhard="docker-compose -p launchpad down --volumes"
+alias dbreset="ddown && docker volume rm dbvolume"
 
 # Usage: dkimages
 alias dkimages="docker rmi $(docker images -f 'dangling=true' -q) || echo No images to kill"
@@ -104,6 +104,6 @@ The ENV variable `POSTGRES_HOST` defaults to `db` which is the name used in `doc
 
 The `-p launchpad` parameter for `dup` and `ddown` scopes all containers to the `project` launchpad. This allows you to easily bring all containers up and down.
 
-It is important to note that the `--volumes` flag in alias  `ddown` will remove any associated volumes. In this case the volume for Postgres is deleted each time you run ddown or dup.
+By default `ddown` will simply stop the containers. If you want to nuke the database then run `dbreset` which will bring down the containers and remove the named volume `dbvolume` which the postres container depends on.
 
 In `dup` the flag `--build` is important because it actually re-builds the docker images, if you have any changes, before bringing the containers up.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ db:
   container_name: db
   restart: always
   build: ./database
+  volumes:
+    - dbvolume:/var/lib/postgresql/data
   expose:
     - "${POSTGRES_PORT}"
   ports:


### PR DESCRIPTION
Using a named volume will prevent docker-compose from creating a new volume each time you go up.
Add a command dbreset which deletes the database